### PR TITLE
[crestron_home] Milestone 0 — custom integration scaffold

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,0 +1,17 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run hassfest
+        uses: home-assistant/actions/hassfest@master
+        with:
+          action: validate
+          integration-path: custom_components/crestron_home

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.swp
+.mypy_cache/
+.pytest_cache/
+.sample_config/
+sample_config/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sam Harwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# ha-crestron-home
-One-off Crestron Home integration for Home Assistant
+# Crestron Home integration for Home Assistant
+
+This repository hosts a custom [Home Assistant](https://www.home-assistant.io/) integration named **Crestron Home**.
+Milestone 0 provides a scaffold that advertises the integration in Home Assistant's
+**Add Integration** dialog but intentionally stops short of connecting to a
+Crestron Home system.
+
+## Installation
+
+1. Copy `custom_components/crestron_home` to the `custom_components`
+   directory inside your Home Assistant configuration.
+2. Restart Home Assistant.
+3. Open **Settings → Devices & Services → Add Integration** and search for
+   "Crestron Home".
+
+At this stage the configuration flow aborts with a friendly message while the
+integration is under active development.
+
+## Development
+
+Run [`hassfest`](https://developers.home-assistant.io/docs/hassfest/) before
+submitting changes to validate the integration metadata:
+
+```bash
+pipx run hassfest --action validate --integration-path custom_components/crestron_home
+```
+
+Future milestones will add authentication, communication with the Crestron Home
+system, and entity platforms for controlling devices such as covers.

--- a/custom_components/crestron_home/__init__.py
+++ b/custom_components/crestron_home/__init__.py
@@ -1,0 +1,25 @@
+"""Crestron Home integration scaffold."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Crestron Home integration."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Crestron Home from a config entry."""
+    # Placeholder for future implementation.
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Crestron Home config entry."""
+    return True

--- a/custom_components/crestron_home/config_flow.py
+++ b/custom_components/crestron_home/config_flow.py
@@ -1,0 +1,19 @@
+"""Config flow for the Crestron Home integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant import config_entries
+
+from .const import DOMAIN
+
+
+class CrestronHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Crestron Home."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> config_entries.FlowResult:
+        """Handle the initial step initiated by the user."""
+        return self.async_abort(reason="setup_not_implemented")

--- a/custom_components/crestron_home/const.py
+++ b/custom_components/crestron_home/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Crestron Home integration."""
+
+DOMAIN = "crestron_home"

--- a/custom_components/crestron_home/manifest.json
+++ b/custom_components/crestron_home/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "crestron_home",
+  "name": "Crestron Home",
+  "version": "0.0.0",
+  "documentation": "https://github.com/sharwell/ha-crestron-home",
+  "config_flow": true,
+  "codeowners": [
+    "@sharwell"
+  ],
+  "iot_class": "local_polling"
+}

--- a/custom_components/crestron_home/strings.json
+++ b/custom_components/crestron_home/strings.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "title": "Crestron Home",
+    "abort": {
+      "setup_not_implemented": "Setup for Crestron Home is not implemented yet."
+    }
+  }
+}

--- a/custom_components/crestron_home/translations/en.json
+++ b/custom_components/crestron_home/translations/en.json
@@ -1,0 +1,8 @@
+{
+  "config": {
+    "title": "Crestron Home",
+    "abort": {
+      "setup_not_implemented": "Setup for Crestron Home is not implemented yet."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold the `crestron_home` custom integration with a manifest, constants, placeholder setup, and a config flow that aborts with a friendly message
- add baseline user-facing strings, translations, and documentation describing installation and current limitations
- configure hassfest CI workflow and repository housekeeping files (license, .gitignore) for ongoing validation

## Validation
- [ ] `pipx run --spec homeassistant hassfest --action validate --integration-path custom_components/crestron_home` *(fails in this environment because the packaged hassfest script requires Python 3.13+)*
- [ ] Home Assistant UI smoke test *(pending — requires manual HA environment)*

## Follow-ups
- Milestone 1: implement Crestron Home client/authentication, establish config entry data model, and deliver initial cover platform support.

## Open Questions
- Should the integration support automatic discovery of Crestron Home controllers, or rely solely on manual configuration?

## Risk & Rollback
- Low risk: changes are additive and limited to the new scaffold. Roll back by removing the `custom_components/crestron_home` directory and associated workflow if issues arise.


------
https://chatgpt.com/codex/tasks/task_e_68d3fa93101c8333b6e48817601beecf