### PR TITLE
[crestron_home] Milestone 0 — custom integration scaffold

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,0 +1,17 @@
+name: Validate integration with hassfest
+
+on:
+  push:
+    branches:
+      - main
+      - m0-scaffold
+  pull_request:
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Run hassfest
+        uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -7,10 +7,6 @@ on:
       - "rel/*"
       - "val/*"
   pull_request:
-    branches:
-      - main
-      - "rel/*"
-      - "val/*"
 
 jobs:
   hassfest:

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -4,8 +4,13 @@ on:
   push:
     branches:
       - main
-      - m0-scaffold
+      - "rel/*"
+      - "val/*"
   pull_request:
+    branches:
+      - main
+      - "rel/*"
+      - "val/*"
 
 jobs:
   hassfest:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.hass_cache/
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Crestron Home Integration Authors
+Copyright (c) 2025 Sam Harwell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Crestron Home Integration Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# ha-crestron-home
-One-off Crestron Home integration for Home Assistant
+# Crestron Home integration for Home Assistant
+
+Milestone 0 (M0) provides a scaffold for the future Crestron Home custom integration. The
+integration can be discovered from **Settings → Devices & Services → Add Integration**, where a
+placeholder config flow aborts with a friendly message that setup is not yet implemented.
+
+## Development setup
+
+1. Clone [home-assistant/core](https://github.com/home-assistant/core) next to this repository:
+   ```bash
+   git clone --depth=1 https://github.com/home-assistant/core hass-core
+   ```
+2. Run hassfest validation against the integration scaffold:
+   ```bash
+   (cd hass-core && python3 -m script.hassfest --action validate --integration-path ../custom_components/crestron_home)
+   ```
+
+## Roadmap
+
+- **Milestone 1:** Implement API client, authentication, and initial cover platform support.
+- **Milestone 2+:** Expand device coverage, add tests, and integrate discovery/onboarding flows.
+
+## License
+
+This project is licensed under the terms of the MIT license. See [LICENSE](LICENSE) for details.

--- a/custom_components/crestron_home/__init__.py
+++ b/custom_components/crestron_home/__init__.py
@@ -1,0 +1,24 @@
+"""Crestron Home integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Crestron Home from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    _LOGGER.debug("Setup requested for config entry %s", entry.entry_id)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Crestron Home config entry."""
+    _LOGGER.debug("Unload requested for config entry %s", entry.entry_id)
+    return True

--- a/custom_components/crestron_home/config_flow.py
+++ b/custom_components/crestron_home/config_flow.py
@@ -1,0 +1,16 @@
+"""Config flow for the Crestron Home integration."""
+from __future__ import annotations
+
+from homeassistant import config_entries
+
+from .const import DOMAIN
+
+
+class CrestronHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Crestron Home."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step of the config flow."""
+        return self.async_abort(reason="not_implemented")

--- a/custom_components/crestron_home/const.py
+++ b/custom_components/crestron_home/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Crestron Home integration."""
+
+DOMAIN = "crestron_home"

--- a/custom_components/crestron_home/manifest.json
+++ b/custom_components/crestron_home/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "crestron_home",
+  "name": "Crestron Home",
+  "codeowners": ["@sharwell"],
+  "config_flow": true,
+  "documentation": "https://github.com/sharwell/ha-crestron-home",
+  "iot_class": "local_polling",
+  "version": "0.0.1"
+}

--- a/custom_components/crestron_home/strings.json
+++ b/custom_components/crestron_home/strings.json
@@ -1,0 +1,13 @@
+{
+  "title": "Crestron Home",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Crestron Home"
+      }
+    },
+    "abort": {
+      "not_implemented": "Setup not implemented yet."
+    }
+  }
+}

--- a/custom_components/crestron_home/translations/en.json
+++ b/custom_components/crestron_home/translations/en.json
@@ -1,0 +1,13 @@
+{
+  "title": "Crestron Home",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Crestron Home"
+      }
+    },
+    "abort": {
+      "not_implemented": "Setup not implemented yet."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold the `crestron_home` custom integration with a placeholder config flow that aborts setup and performs no I/O
- document the milestone scope and hassfest validation steps for contributors
- add a hassfest GitHub Actions workflow to gate structural regressions

## Testing
- [x] `(cd hass-core && python3 -m script.hassfest --action validate --integration-path ../custom_components/crestron_home)`

## Acceptance Criteria
- [x] Hassfest validates the scaffold — `(cd hass-core && python3 -m script.hassfest --action validate --integration-path ../custom_components/crestron_home)`

## Rollback Plan
- `git revert 6c327a953601fcb99c9af6a84c7ddb8750d2d155`

## Follow-ups
- Milestone 1: Build the API client, authentication/connection handling, and initial cover platform implementation

## Open Questions
- Should future setup rely on discovery or remain manual-only until the API client is complete?


------
https://chatgpt.com/codex/tasks/task_e_68d4180b7c988333b2912b2f7a0a8b66