### PR TITLE
Add hacs manifest

### DIFF
--- a/custom_components/crestron_home/manifest.json
+++ b/custom_components/crestron_home/manifest.json
@@ -4,6 +4,7 @@
   "codeowners": ["@sharwell"],
   "config_flow": true,
   "documentation": "https://github.com/sharwell/ha-crestron-home",
+  "issue_tracker": "https://github.com/sharwell/ha-crestron-home/issues",
   "iot_class": "local_polling",
   "version": "0.0.1"
 }

--- a/custom_components/crestron_home/manifest.json
+++ b/custom_components/crestron_home/manifest.json
@@ -4,7 +4,7 @@
   "codeowners": ["@sharwell"],
   "config_flow": true,
   "documentation": "https://github.com/sharwell/ha-crestron-home",
-  "issue_tracker": "https://github.com/sharwell/ha-crestron-home/issues",
   "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/sharwell/ha-crestron-home/issues",
   "version": "0.0.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Crestron Home",
+  "content_in_root": false,
+  "render_readme": true,
+  "domains": ["crestron_home"]
+}


### PR DESCRIPTION
## Summary
- add a hacs.json manifest describing the Crestron Home integration layout for HACS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d426749cbc8333bd35194ed3e09e03