### PR TITLE
Handle lowercase auth key in login response

### DIFF
--- a/custom_components/crestron_home/api.py
+++ b/custom_components/crestron_home/api.py
@@ -111,7 +111,7 @@ class ApiClient:
             except (ContentTypeError, ValueError) as err:
                 raise CrestronHomeApiError("Controller response was not JSON") from err
 
-            auth_key = data.get("AuthKey")
+            auth_key = data.get("authkey") or data.get("AuthKey")
             if not auth_key:
                 raise CrestronHomeApiError("Controller response did not include an auth key")
 

--- a/custom_components/crestron_home/api.py
+++ b/custom_components/crestron_home/api.py
@@ -111,7 +111,7 @@ class ApiClient:
             except (ContentTypeError, ValueError) as err:
                 raise CrestronHomeApiError("Controller response was not JSON") from err
 
-            auth_key = data.get("authkey") or data.get("AuthKey")
+            auth_key = data.get("authkey")
             if not auth_key:
                 raise CrestronHomeApiError("Controller response did not include an auth key")
 


### PR DESCRIPTION
## Summary
- allow the login flow to read the lowercase `authkey` field returned by the controller

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d434252e2483339b41afaab322d876