### PR TITLE
Fix Crestron Home shade closed state calculation

### DIFF
--- a/custom_components/crestron_home/cover.py
+++ b/custom_components/crestron_home/cover.py
@@ -130,6 +130,16 @@ class CrestronHomeShade(CoordinatorEntity[ShadesCoordinator], CoverEntity):
         return _convert_position_to_percentage(shade.position, invert)
 
     @property
+    def is_closed(self) -> bool | None:
+        """Return whether the shade is closed."""
+
+        position = self.current_cover_position
+        if position is None:
+            return None
+
+        return position <= 0
+
+    @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         shade = self.shade
         if shade is None:


### PR DESCRIPTION
## Summary
- compute the Crestron Home shade closed state from the current cover position to avoid missing attribute errors

## Testing
- python -m compileall custom_components/crestron_home

------
https://chatgpt.com/codex/tasks/task_e_68d43fa5a2fc8333a287bf814a3ff54b