### PR TITLE
[crestron_home] Milestone 3 — write control + batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ Assistant cover entities.
 - Availability is derived from the controller's `connectionStatus` value. Offline shades appear as
   unavailable in Home Assistant until the controller reports them as connected again.
 
+### Shade control (Milestone 3)
+
+- Shade entities now implement Home Assistant's `open_cover`, `close_cover`, and
+  `set_cover_position` services. Requests apply the global invert option and scale between
+  Home Assistant's 0–100% representation and Crestron's 0–65535 range.
+- Commands enqueue into a per-controller batcher. Calls landing within an 80 ms window coalesce
+  into one `POST /cws/api/shades/SetState` request (up to 16 shades per batch) so grouped scenes
+  lift together. Duplicate writes for the same shade keep the latest position before the batch is
+  sent.
+- After any successful write (full or partial), the coordinator bumps into fast polling (≈10 s at
+  1–2 s intervals) so Home Assistant state converges quickly with the controller's telemetry.
+- To verify batching manually, enable debug logging (see `sample_config/configuration.yaml` in the
+  repo) and trigger a scene that adjusts eight shades at once. A single DEBUG line similar to
+  `POST /shades/SetState items=8 ids=[...] status=success` confirms one request served the entire
+  batch.
+
 ## Development setup
 
 1. Clone [home-assistant/core](https://github.com/home-assistant/core) next to this repository:

--- a/custom_components/crestron_home/const.py
+++ b/custom_components/crestron_home/const.py
@@ -22,11 +22,49 @@ MIME_TYPE_JSON = "application/json"
 PATH_LOGIN = "/cws/api/login"
 PATH_ROOMS = "/cws/api/rooms"
 PATH_SHADES = "/cws/api/shades"
+PATH_SHADES_SET_STATE = "/cws/api/shades/SetState"
 
 DATA_API_CLIENT = "api_client"
 DATA_SHADES_COORDINATOR = "shades_coordinator"
+DATA_WRITE_BATCHER = "write_batcher"
 
 SHADE_POSITION_MAX = 65535
 SHADE_POLL_INTERVAL_IDLE = 12
 SHADE_POLL_INTERVAL_FAST = 1.5
 SHADE_BOOST_SECONDS = 10
+
+BATCH_DEBOUNCE_MS = 80
+BATCH_MAX_ITEMS = 16
+
+
+def raw_to_pct(raw: int | None, invert: bool) -> int | None:
+    """Convert a Crestron raw position value to a Home Assistant percentage."""
+
+    if raw is None:
+        return None
+
+    if raw < 0:
+        raw = 0
+    elif raw > SHADE_POSITION_MAX:
+        raw = SHADE_POSITION_MAX
+
+    percentage = round(raw * 100 / SHADE_POSITION_MAX)
+    if invert:
+        percentage = 100 - percentage
+
+    return max(0, min(100, percentage))
+
+
+def pct_to_raw(percentage: int, invert: bool) -> int:
+    """Convert a Home Assistant percentage to a Crestron raw position value."""
+
+    pct = max(0, min(100, int(percentage)))
+    if invert:
+        pct = 100 - pct
+
+    raw = round(pct * SHADE_POSITION_MAX / 100)
+    if raw < 0:
+        return 0
+    if raw > SHADE_POSITION_MAX:
+        return SHADE_POSITION_MAX
+    return raw

--- a/custom_components/crestron_home/coordinator.py
+++ b/custom_components/crestron_home/coordinator.py
@@ -215,3 +215,8 @@ class ShadesCoordinator(DataUpdateCoordinator[dict[str, Shade]]):
         target = self._fast_interval if self._boost_until else self._idle_interval
         if self.update_interval != target:
             self.update_interval = target
+
+    def bump_fast_poll(self, seconds: float = SHADE_BOOST_SECONDS) -> None:
+        """Public helper to temporarily poll faster after a write."""
+
+        self.boost(seconds)

--- a/custom_components/crestron_home/strings.json
+++ b/custom_components/crestron_home/strings.json
@@ -43,5 +43,16 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "error_write_failed": {
+      "message": "Failed to send commands to the controller."
+    },
+    "error_partial_write": {
+      "message": "Shade command failed for {shade_id}: {reason}"
+    },
+    "error_write_disabled": {
+      "message": "Shade control is shutting down."
+    }
   }
 }

--- a/custom_components/crestron_home/translations/en.json
+++ b/custom_components/crestron_home/translations/en.json
@@ -43,5 +43,16 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "error_write_failed": {
+      "message": "Failed to send commands to the controller."
+    },
+    "error_partial_write": {
+      "message": "Shade command failed for {shade_id}: {reason}"
+    },
+    "error_write_disabled": {
+      "message": "Shade control is shutting down."
+    }
   }
 }

--- a/custom_components/crestron_home/write.py
+++ b/custom_components/crestron_home/write.py
@@ -1,0 +1,228 @@
+"""Batch writer for Crestron Home shade commands."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.translation import async_get_cached_translations
+
+from .api import ApiClient, CrestronHomeApiError, ShadeCommandFailedError, ShadeCommandResult
+from .const import BATCH_DEBOUNCE_MS, BATCH_MAX_ITEMS, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _QueuedItem:
+    shade_id: str
+    position: int
+
+
+class ShadeWriteBatcher:
+    """Batch writes to the Crestron Home shade API."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: ApiClient,
+        *,
+        debounce_ms: int = BATCH_DEBOUNCE_MS,
+        max_items: int = BATCH_MAX_ITEMS,
+        on_success: Callable[[], None] | None = None,
+    ) -> None:
+        self._hass = hass
+        self._client = client
+        self._debounce_seconds = max(0, debounce_ms) / 1000
+        self._max_items = max(1, max_items)
+        self._lock = asyncio.Lock()
+        self._queue: dict[str, _QueuedItem] = {}
+        self._waiters: dict[str, list[asyncio.Future[None]]] = defaultdict(list)
+        self._timer: asyncio.TimerHandle | None = None
+        self._flush_task: asyncio.Task[None] | None = None
+        self._closed = False
+        self._on_success = on_success
+
+    async def enqueue(self, shade_id: str, position: int) -> None:
+        """Enqueue a shade write request and wait for completion."""
+
+        if self._closed:
+            raise HomeAssistantError(self._translate("error_write_disabled"))
+
+        future: asyncio.Future[None] = self._hass.loop.create_future()
+        self._queue[shade_id] = _QueuedItem(shade_id=shade_id, position=position)
+        self._waiters[shade_id].append(future)
+
+        if len(self._queue) >= self._max_items:
+            self._cancel_timer()
+            await self._flush_now()
+        else:
+            self._schedule_timer()
+
+        await future
+
+    def _schedule_timer(self) -> None:
+        if self._debounce_seconds <= 0:
+            self._hass.async_create_task(self._flush_now())
+            return
+        if self._timer is not None:
+            return
+
+        def _on_timer() -> None:
+            self._timer = None
+            self._hass.async_create_task(self._flush_now())
+
+        self._timer = self._hass.loop.call_later(self._debounce_seconds, _on_timer)
+
+    def _cancel_timer(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
+    async def _flush_now(self) -> None:
+        if self._flush_task and not self._flush_task.done():
+            await self._flush_task
+            return
+
+        self._flush_task = self._hass.async_create_task(self._flush())
+        try:
+            await self._flush_task
+        finally:
+            self._flush_task = None
+
+    async def _flush(self) -> None:
+        async with self._lock:
+            if not self._queue:
+                return
+
+            queued_items = self._queue
+            waiters = self._waiters
+            self._queue = {}
+            self._waiters = defaultdict(list)
+
+        payload = [
+            {"id": item.shade_id, "position": item.position}
+            for item in queued_items.values()
+        ]
+
+        ids = [item.shade_id for item in queued_items.values()]
+
+        try:
+            response = await self._client.async_set_shade_positions(payload)
+        except ShadeCommandFailedError as err:
+            error = HomeAssistantError(self._translate("error_write_failed"))
+            self._reject_all(waiters, error)
+            raise error from err
+        except CrestronHomeApiError as err:
+            error = HomeAssistantError(self._translate("error_write_failed"))
+            self._reject_all(waiters, error)
+            raise error from err
+        except Exception as err:  # pragma: no cover - defensive safeguard
+            error = HomeAssistantError(self._translate("error_write_failed"))
+            self._reject_all(waiters, error)
+            raise error from err
+
+        status = response.status
+        _LOGGER.debug(
+            "POST /shades/SetState items=%s ids=%s status=%s",
+            len(payload),
+            ids,
+            status,
+        )
+
+        if self._on_success is not None:
+            self._on_success()
+
+        default_status = "success" if status in {"success", "partial"} else status
+
+        failed: dict[str, ShadeCommandResult] = {}
+        for shade_id, item in queued_items.items():
+            result = response.results.get(shade_id)
+            if result is None:
+                result = ShadeCommandResult(status=default_status)
+
+            if result.status != "success":
+                failed[shade_id] = result
+                error = HomeAssistantError(
+                    self._translate(
+                        "error_partial_write",
+                        shade_id=shade_id,
+                        reason=result.message or result.status,
+                    )
+                )
+                for future in waiters.get(shade_id, []):
+                    if not future.done():
+                        future.set_exception(error)
+            else:
+                for future in waiters.get(shade_id, []):
+                    if not future.done():
+                        future.set_result(None)
+
+        if failed:
+            self._log_partial_failure(failed)
+        else:
+            self._resolve_remaining(waiters)
+
+    def _reject_all(
+        self,
+        waiters: dict[str, list[asyncio.Future[None]]],
+        err: Exception,
+    ) -> None:
+        for futures in waiters.values():
+            for future in futures:
+                if not future.done():
+                    future.set_exception(err)
+
+    def _resolve_remaining(self, waiters: dict[str, list[asyncio.Future[None]]]) -> None:
+        for futures in waiters.values():
+            for future in futures:
+                if not future.done():
+                    future.set_result(None)
+
+    def _log_partial_failure(self, failed: dict[str, ShadeCommandResult]) -> None:
+        entries = [
+            "%s (%s)" % (shade_id, result.message or result.status)
+            for shade_id, result in failed.items()
+        ]
+        _LOGGER.warning(
+            "Partial shade write failure for ids: %s",
+            ", ".join(entries),
+        )
+
+    async def async_shutdown(self) -> None:
+        """Cancel scheduled flushes and process remaining items."""
+
+        self._closed = True
+        self._cancel_timer()
+        if self._queue:
+            try:
+                await self._flush_now()
+            except HomeAssistantError:
+                pass
+        if self._flush_task and not self._flush_task.done():
+            await self._flush_task
+
+    def _translate(self, key: str, **kwargs: Any) -> str:
+        language = self._hass.config.language
+        translations = async_get_cached_translations(
+            self._hass, language, "exceptions", DOMAIN
+        )
+        translation_key = f"component.{DOMAIN}.exceptions.{key}.message"
+        template = translations.get(translation_key)
+        if not template:
+            fallback = {
+                "error_write_disabled": "Shade control is shutting down",
+                "error_write_failed": "Failed to send shade command",
+                "error_partial_write": "Shade command failed for {shade_id}: {reason}",
+            }
+            template = fallback.get(key, key)
+        try:
+            return template.format(**kwargs)
+        except (KeyError, ValueError):
+            return template


### PR DESCRIPTION
## Summary
- add `ApiClient.async_set_shade_positions` to post batched shade commands with auth retry and per-shade outcomes
- introduce a per-entry `ShadeWriteBatcher` that coalesces writes, deduplicates shade ids, and bumps fast polling on success
- expose open/close/set-position cover services with invert-aware scaling, update user-facing docs, and add error translations

## Testing
- `python3 -m script.hassfest --action validate --integration-path ../custom_components/crestron_home`

## Acceptance Criteria
- [x] Scene/automation calls within ~80 ms coalesce into a single POST with one item per shade.
- [x] Rapid successive requests for the same shade keep only the last value before flush.
- [x] POST retries once after a 401/511, then surfaces errors via `HomeAssistantError`.
- [x] Partial successes log failed ids at WARNING and raise `HomeAssistantError` for those services.
- [x] Successful writes trigger the fast-poll window so state converges quickly.

## Follow-ups
- STOP command support if a Crestron endpoint exists.
- Per-entity invert overrides and broader device coverage.
- Diagnostics/reporting for batched writes.

## Open Questions
- Confirm final SetState response schema nuances (list vs dict, status strings).
- Controller-imposed maximum POST size for large installs.
- Ideal debounce window for very large scenes.

## Rollback Plan
- Revert this PR (`git revert` of the merge commit).

------
https://chatgpt.com/codex/tasks/task_e_68d44389b2348333b6181e08dab655a8