### PR TITLE
Fix async_request_refresh warning in coordinator

### DIFF
--- a/custom_components/crestron_home/coordinator.py
+++ b/custom_components/crestron_home/coordinator.py
@@ -142,7 +142,7 @@ class ShadesCoordinator(DataUpdateCoordinator[dict[str, Shade]]):
         if self._boost_until is None or until > self._boost_until:
             self._boost_until = until
         self._refresh_polling_interval()
-        self.async_request_refresh()
+        self.hass.async_create_task(self.async_request_refresh())
 
     async def _async_update_data(self) -> dict[str, Shade]:
         """Fetch shade data from the controller."""


### PR DESCRIPTION
## Summary
- schedule the coordinator refresh via Home Assistant task creation when boosting to avoid the warning about an un-awaited coroutine

## Testing
- python -m compileall custom_components/crestron_home

------
https://chatgpt.com/codex/tasks/task_e_68d450e9c304833392e1cf021e3c8c11