### PR TITLE
Avoid assigning config_entry in options flow

### DIFF
--- a/custom_components/crestron_home/config_flow.py
+++ b/custom_components/crestron_home/config_flow.py
@@ -194,7 +194,7 @@ class CrestronHomeOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options for the Crestron Home integration."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
         base_options = dict(config_entry.options)
         self._options: dict[str, Any] = copy.deepcopy(base_options)
@@ -212,7 +212,7 @@ class CrestronHomeOptionsFlowHandler(config_entries.OptionsFlow):
         domain_data = self.hass.data.get(DOMAIN)
         if not domain_data:
             return None
-        entry_data = domain_data.get(self.config_entry.entry_id)
+        entry_data = domain_data.get(self._config_entry.entry_id)
         if not entry_data:
             return None
         coordinator = entry_data.get(DATA_SHADES_COORDINATOR)


### PR DESCRIPTION
## Summary
- stop assigning the config entry directly on the options flow handler to avoid the upcoming Home Assistant deprecation
- look up domain data using the stored entry identifier

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4603839888333962ab56319397bdb