### PR TITLE
Fix selector values for shade dropdown

### DIFF
--- a/custom_components/crestron_home/config_flow.py
+++ b/custom_components/crestron_home/config_flow.py
@@ -385,7 +385,7 @@ class CrestronHomeOptionsFlowHandler(config_entries.OptionsFlow):
 
         if choices:
             options = [
-                {"value": shade_id, "label": label}
+                {"value": str(shade_id), "label": str(label)}
                 for shade_id, label in choices.items()
             ]
             shade_selector = selector.selector(


### PR DESCRIPTION
## Summary
- ensure shade selector options always use string values to satisfy Home Assistant selector requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4848fd2408333a7c0f9367170d8b6